### PR TITLE
SASS-4998: Add endpoint to StateBenefits Service for Saving payloads …

### DIFF
--- a/app/services/StateBenefitsService.scala
+++ b/app/services/StateBenefitsService.scala
@@ -60,10 +60,11 @@ class StateBenefitsService @Inject()(ifService: IntegrationFrameworkService,
   def updateSessionData(userData: StateBenefitsUserData): Future[Either[ServiceError, UUID]] =
     createOrUpdateUserSessionData(userData).value
 
-  def saveClaim(stateBenefitsUserData: StateBenefitsUserData)
+  def saveClaim(stateBenefitsUserData: StateBenefitsUserData, useSessionData: Boolean = true)
                (implicit hc: HeaderCarrier): Future[Either[ServiceError, Unit]] = {
     val response = for {
-      data <- findSessionData(stateBenefitsUserData.nino, stateBenefitsUserData.sessionDataId.get)
+      data <- if (useSessionData) { findSessionData(stateBenefitsUserData.nino, stateBenefitsUserData.sessionDataId.get) }
+                 else {EitherT(Future(Either.cond(test = true, stateBenefitsUserData, ApiServiceError("saveClaim with StateBenefitsUserData"))))}
       _ <- saveStateBenefitsUserData(data)
       _ <- refreshSubmissionServiceData(data)
       _ <- clearSessionData(data)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -9,5 +9,6 @@ POST    /session-data                                               controllers.
 PUT     /session-data/nino/:nino/session/:sessionDataId             controllers.SessionDataController.update(nino: String, sessionDataId: java.util.UUID)
 
 PUT     /claim-data/nino/:nino/session/:sessionDataId               controllers.ClaimDataController.save(nino: String, sessionDataId: java.util.UUID)
+PUT     /claim-data/nino/:nino                                      controllers.ClaimDataController.saveByData(nino: String)
 DELETE  /claim-data/nino/:nino/session/:sessionDataId               controllers.ClaimDataController.remove(nino: String, sessionDataId: java.util.UUID)
 DELETE  /claim-data/nino/:nino/session/:sessionDataId/ignore        controllers.ClaimDataController.restore(nino: String, sessionDataId: java.util.UUID)

--- a/test/services/StateBenefitsServiceSpec.scala
+++ b/test/services/StateBenefitsServiceSpec.scala
@@ -136,7 +136,7 @@ class StateBenefitsServiceSpec extends UnitTest
       await(underTest.saveClaim(userData)) shouldBe Left(MongoError("some-error"))
     }
 
-    "perform save a claim when all calls succeed" in {
+    "perform save a claim when all calls succeed when provided with a sessionId" in {
       val userData = aStateBenefitsUserData
       mockFind(userData.nino, sessionDataId, Right(userData))
       mockSaveStateBenefitsUserData(userData, Right(benefitId))
@@ -144,6 +144,15 @@ class StateBenefitsServiceSpec extends UnitTest
       mockClear(userData.sessionId, result = Right(()))
 
       await(underTest.saveClaim(userData)) shouldBe Right(())
+    }
+
+    "perform save a claim when all calls succeed when a sessionId is not provided" in {
+      val userData = aStateBenefitsUserData
+      mockSaveStateBenefitsUserData(userData, Right(benefitId))
+      mockRefreshStateBenefits(userData.taxYear, userData.nino, userData.mtdItId, Right(()))
+      mockClear(userData.sessionId, result = Right(()))
+
+      await(underTest.saveClaim(userData, useSessionData = false)) shouldBe Right(())
     }
   }
 

--- a/test/support/mocks/MockStateBenefitsService.scala
+++ b/test/support/mocks/MockStateBenefitsService.scala
@@ -75,9 +75,9 @@ trait MockStateBenefitsService extends MockFactory {
   }
 
   def mockSaveUserData(userData: StateBenefitsUserData,
-                       result: Either[ServiceError, Unit]): CallHandler2[StateBenefitsUserData, HeaderCarrier, Future[Either[ServiceError, Unit]]] = {
-    (mockStateBenefitsService.saveClaim(_: StateBenefitsUserData)(_: HeaderCarrier))
-      .expects(userData, *)
+                       result: Either[ServiceError, Unit]): CallHandler3[StateBenefitsUserData, Boolean, HeaderCarrier, Future[Either[ServiceError, Unit]]] = {
+    (mockStateBenefitsService.saveClaim(_: StateBenefitsUserData, _:Boolean)(_: HeaderCarrier))
+      .expects(userData, *, *)
       .returning(Future.successful(result))
   }
 


### PR DESCRIPTION
…not originating from Statebenefits FE

Added save by data endpoint to ClaimDataController to enable state benefit user data save by payload without internal sessionId

### Description
Please include a brief summary of the change you've made and the issue that it fixes.

Add a link to the relevant story in Jira
[SASS-CHANGE-ME](ADD URL HERE)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [ ]  Have you assigned yourself to the PR?
- [ ]  Have you moved the task to “in review” on JIRA?
- [ ]  Have you checked to ensure all dependencies are up to date?
- [ ]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests?
- [ ]  Have you run the smoke tests?
- [ ]  Have you run the performance tests?
- [ ]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [ ]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [ ]  Have you run the smoke tests? (where applicable)
- [ ]  Have you run the performance tests? (where applicable)
- [ ]  Have you addressed warnings where appropriate?
- [ ]  Have you rebased against the current version of main?
- [ ]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
