### PR TITLE
[SASS-3442] Allow None sessionDataId

### DIFF
--- a/app/controllers/ClaimDataController.scala
+++ b/app/controllers/ClaimDataController.scala
@@ -63,7 +63,7 @@ class ClaimDataController @Inject()(authorisedAction: AuthorisedAction,
 
   private def handleSaveUserData(nino: String, sessionDataId: Option[UUID], userData: StateBenefitsUserData)
                                 (implicit hc: HeaderCarrier): Future[Result] = {
-    if (userData.nino != nino || !userData.sessionDataId.exists(sId => sId == sessionDataId.getOrElse(sId))) {
+    if (userData.nino != nino || !userData.sessionDataId.equals(sessionDataId)) {
       logger.warn(invalidRequestLogMessage)
       Future.successful(BadRequest)
     } else {

--- a/app/services/IntegrationFrameworkService.scala
+++ b/app/services/IntegrationFrameworkService.scala
@@ -74,8 +74,8 @@ class IntegrationFrameworkService @Inject()(connector: IntegrationFrameworkConne
 
   private def createOrUpdateStateBenefit(userData: StateBenefitsUserData)
                                         (implicit hc: HeaderCarrier): EitherT[Future, ApiServiceError, UUID] = userData match {
-    case _ if userData.isHmrcData => createCustomerOverride(userData)
     case _ if userData.isNewClaim => addCustomerStateBenefit(userData)
+    case _ if userData.isHmrcData => createCustomerOverride(userData)
     case _ => updateCustomerStateBenefit(userData)
   }
 

--- a/test/controllers/ClaimDataControllerSpec.scala
+++ b/test/controllers/ClaimDataControllerSpec.scala
@@ -44,36 +44,38 @@ class ClaimDataControllerSpec extends ControllerUnitTest
 
   ".save" should {
     for (saveType <- Seq("save by sessionId", "save by userData")) {
-      
+
+      val userData = if (saveType.contains("save by sessionId")) aStateBenefitsUserData else aStateBenefitsUserData.copy(sessionDataId = None)
+
       s"$saveType" should {
 
         "return BadRequest" when {
           s"when data received is in invalid format" in {
             mockAuthorisation()
-            
+
             val request = fakePutRequest.withJsonBody(Json.parse("""{"wrongFormat": "wrong-value"}"""))
             val result =
               if (saveType.contains("save by sessionId")) underTest.save(nino, sessionDataId)(request) else underTest.saveByData(nino)(request)
-              
+
             status(result) shouldBe BAD_REQUEST
           }
 
           s"when nino is different" in {
             mockAuthorisation()
-            
-            val request = fakePostRequest.withJsonBody(Json.toJson(aStateBenefitsUserData))
+
+            val request = fakePostRequest.withJsonBody(Json.toJson(userData))
             val result =
               if (saveType.contains("save by sessionId")) underTest.save("some-nino", sessionDataId)(request) else underTest.saveByData("some-nino")(request)
-              
+
             status(result) shouldBe BAD_REQUEST
           }
 
           if (saveType.contains("save by sessionId")) {
             "when sessionDataId is different" in {
               mockAuthorisation()
-              
-              val result = underTest.save(nino, UUID.randomUUID())(fakePostRequest.withJsonBody(Json.toJson(aStateBenefitsUserData)))
-              
+
+              val result = underTest.save(nino, UUID.randomUUID())(fakePostRequest.withJsonBody(Json.toJson(userData)))
+
               status(result) shouldBe BAD_REQUEST
             }
           }
@@ -81,9 +83,9 @@ class ClaimDataControllerSpec extends ControllerUnitTest
 
         s"should return INTERNAL_SERVER_ERROR when saveUserData returns an error" in {
           mockAuthorisation()
-          mockSaveUserData(aStateBenefitsUserData, Left(DataNotUpdatedError))
+          mockSaveUserData(userData, Left(DataNotUpdatedError))
 
-          val request = fakePutRequest.withJsonBody(Json.toJson(aStateBenefitsUserData))
+          val request = fakePutRequest.withJsonBody(Json.toJson(userData))
           val result =
             if (saveType.contains("save by sessionId")) underTest.save(nino, sessionDataId)(request) else underTest.saveByData(nino)(request)
 
@@ -92,9 +94,9 @@ class ClaimDataControllerSpec extends ControllerUnitTest
 
         s"should return NoContent when stateBenefitsService returns Right(None)" in {
           mockAuthorisation()
-          mockSaveUserData(aStateBenefitsUserData, Right(()))
+          mockSaveUserData(userData, Right(()))
 
-          val request = fakePutRequest.withJsonBody(Json.toJson(aStateBenefitsUserData))
+          val request = fakePutRequest.withJsonBody(Json.toJson(userData))
           val result =
             if (saveType.contains("save by sessionId")) underTest.save(nino, sessionDataId)(request) else underTest.saveByData(nino)(request)
 


### PR DESCRIPTION
### Description
income-tax-pensions-frontend StatePension CYA submission failing because ClaimCYAModel.sessionDataId is always none. Change allows this to still proceed.

Add a link to the relevant story in Jira
[SASS-3442](https://jira.tools.tax.service.gov.uk/browse/SASS-3442)

### Checklist PR Reviewer
##### Before Reviewing
- [ ]  Have you pulled the branch down?
- [ ]  Have you assigned yourself to the PR?
- [ ]  Have you moved the task to “in review” on JIRA?
- [ ]  Have you checked to ensure all dependencies are up to date?
- [ ]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests?
- [ ]  Have you run the smoke tests?
- [ ]  Have you run the performance tests?
- [ ]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [ ]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [ ]  Have you run the smoke tests? (where applicable)
- [ ]  Have you run the performance tests? (where applicable)
- [ ]  Have you addressed warnings where appropriate?
- [ ]  Have you rebased against the current version of main?
- [ ]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
